### PR TITLE
初期表示時の初期化処理が動かなくなっていた不具合を修正

### DIFF
--- a/components/Conditions.vue
+++ b/components/Conditions.vue
@@ -25,7 +25,7 @@ export default {
     Slider
   },
   data: () => ({
-    strength: 'normal',
+    strength: null,
     total: 4,
     digits: 0,
     symbols: 0,


### PR DESCRIPTION
`normal` → `normal` だと初期化処理が動いていなかった。
