### PR TITLE
数字と記号の合わせた桁数が、ユーザの指定した桁数よりも多くなった場合に期待しない動作になる不具合を修正

### DIFF
--- a/components/Conditions.vue
+++ b/components/Conditions.vue
@@ -2,19 +2,19 @@
   v-card
     v-subheader 生成条件
     v-card-text
-      v-form
+      v-form(ref="form" v-model="valid" lazy-validation)
         v-radio-group(v-model="strength" row)
           v-radio(label="普通" value="normal")
           v-radio(label="強い" value="strong")
           v-radio(label="カスタム" value="custom")
 
-        slider(label="桁数" v-model="total" :min="4" :max="64" :disabled="!isCustom")
-        slider(label="数字の数" v-model="digits" :min="0" :max="10" :disabled="!isCustom")
-        slider(label="記号の数" v-model="symbols" :min="0" :max="10" :disabled="!isCustom")
-        slider(label="生成する数" v-model="generates" :min="1" :max="50")
+        slider(label="桁数" v-model="total" min="4" max="64" :disabled="!isCustom" :rules="rules.total")
+        slider(label="数字の数" v-model="digits" min="0" max="10" :disabled="!isCustom")
+        slider(label="記号の数" v-model="symbols" min="0" max="10" :disabled="!isCustom")
+        slider(label="生成する数" v-model="generates" min="1" max="50")
 
     v-card-actions
-      v-btn(:loading="generating" :disabled="generating" block color="primary" @click="submit") 生成する
+      v-btn(:loading="generating" :disabled="!valid || generating" block color="primary" @click="submit") 生成する
 </template>
 
 <script>
@@ -24,24 +24,43 @@ export default {
   components: {
     Slider
   },
-  data: () => ({
-    strength: null,
-    total: 4,
-    digits: 0,
-    symbols: 0,
-    generates: 5
-  }),
+  data() {
+    return {
+      valid: true,
+      strength: null,
+      total: 4,
+      digits: 0,
+      symbols: 0,
+      generates: 5,
+      rules: {
+        total: [
+          v =>
+            v >= this.dynamicTotalMin ||
+            '数字と記号を合わせた桁数を下回っています'
+        ]
+      }
+    }
+  },
   computed: {
     generating() {
       return this.$store.state.generating
     },
     isCustom() {
       return this.strength === 'custom'
+    },
+    dynamicTotalMin() {
+      return this.digits + this.symbols
     }
   },
   watch: {
     strength() {
       this.setPreset()
+    },
+    digits() {
+      this.adjustLength()
+    },
+    symbols() {
+      this.adjustLength()
     }
   },
   mounted: function() {
@@ -60,6 +79,12 @@ export default {
           this.digits = 5
           this.symbols = 5
           break
+      }
+    },
+    adjustLength() {
+      // 数字・記号の桁数が変わったら、合計の桁数の帳尻を合わせる
+      if (this.total < this.dynamicTotalMin) {
+        this.total = this.dynamicTotalMin
       }
     },
     async submit() {

--- a/components/Slider.vue
+++ b/components/Slider.vue
@@ -1,9 +1,9 @@
 <template lang="pug">
   v-layout
     v-flex.mr-1.number-field
-      v-text-field(type="number" v-model="internalValue" :min="min" :max="max" :label="label" :disabled="disabled")
+      v-text-field(type="number" v-model="internalValue" :min="min" :max="max" :label="label" :disabled="disabled" :rules="rules" error-count="0")
     v-flex
-      v-slider(v-model="internalValue" :min="min" :max="max" :disabled="disabled")
+      v-slider(v-model="internalValue" :min="min" :max="max" :disabled="disabled" :rules="rules")
 </template>
 
 <script>
@@ -28,6 +28,10 @@ export default {
     disabled: {
       type: Boolean,
       default: false
+    },
+    rules: {
+      type: Array,
+      default: () => []
     }
   },
   computed: {


### PR DESCRIPTION
基本方針として、ユーザに余計な操作をさせないようにした。
したがって、なるべく自動的に桁数を調整してくれるようにしてみた。

## 数字・記号の桁数を変えた場合

桁数を上回るように変更された場合、桁数が自動的に変更されるようにした。
最低でも数字＋記号の桁数となるようにしている。

![captured_1](https://user-images.githubusercontent.com/12483929/47481540-d4068780-d86e-11e8-96ba-f25ac45a18ea.gif)

## 桁数をあえて下回るように変更した場合

これはユーザがあえて起こした行動なので、良くないよーってことを知らせるようにした。
具体的にはバリデーションエラー。

![captured_2](https://user-images.githubusercontent.com/12483929/47481581-f00a2900-d86e-11e8-91b1-b5bae263f303.gif)
