### PR TITLE
テキストフィールドで値を変更した場合、文字列型で返却されることによってあらぬバリデーションエラーを引き起こされることがあったのを対応

### DIFF
--- a/components/Conditions.vue
+++ b/components/Conditions.vue
@@ -49,7 +49,7 @@ export default {
       return this.strength === 'custom'
     },
     dynamicTotalMin() {
-      return this.digits + this.symbols
+      return Number(this.digits) + Number(this.symbols)
     }
   },
   watch: {


### PR DESCRIPTION
本当は `5 + 0 = 5` となるべきところが `"5" + 0 = "50"` となってしまっていたバグの修正。

before | after
--- | ---
![captured_1](https://user-images.githubusercontent.com/12483929/47482258-00230800-d871-11e8-96d8-916eda6fec5d.gif) | ![captured_2](https://user-images.githubusercontent.com/12483929/47482259-00230800-d871-11e8-8d7f-1e53da845c4d.gif)
