### PR TITLE
生成条件を vuex 化して localStorage に保持

### DIFF
--- a/components/Conditions.vue
+++ b/components/Conditions.vue
@@ -23,39 +23,75 @@
 </template>
 
 <script>
+import { mapGetters, mapActions } from 'vuex'
 import Slider from '~/components/Slider.vue'
 
 export default {
   components: {
     Slider
   },
-  data() {
-    return {
-      strength: null,
-      total: 0,
-      digits: 0,
-      symbols: 0,
-      generates: 5,
-      symbolChars: []
-    }
-  },
   computed: {
-    generating() {
-      return this.$store.state.generating
+    ...mapGetters(['generating']),
+    ...mapGetters('conditions', ['isCustom', 'SYMBOL_CHARS']),
+    strength: {
+      get() {
+        return this.$store.state.conditions.strength
+      },
+      set(value) {
+        const name = 'strength'
+        this.$store.commit('conditions/update', { name, value })
+      }
     },
-    isCustom() {
-      return this.strength === 'custom'
+    total: {
+      get() {
+        return this.$store.state.conditions.total
+      },
+      set(value) {
+        const name = 'total'
+        this.$store.commit('conditions/update', { name, value })
+      }
+    },
+    digits: {
+      get() {
+        return this.$store.state.conditions.digits
+      },
+      set(value) {
+        const name = 'digits'
+        this.$store.commit('conditions/update', { name, value })
+      }
+    },
+    symbols: {
+      get() {
+        return this.$store.state.conditions.symbols
+      },
+      set(value) {
+        const name = 'symbols'
+        this.$store.commit('conditions/update', { name, value })
+      }
+    },
+    generates: {
+      get() {
+        return this.$store.state.conditions.generates
+      },
+      set(value) {
+        const name = 'generates'
+        this.$store.commit('conditions/update', { name, value })
+      }
+    },
+    symbolChars: {
+      get() {
+        return this.$store.state.conditions.symbolChars
+      },
+      set(value) {
+        const name = 'symbolChars'
+        this.$store.commit('conditions/update', { name, value })
+      }
     },
     dynamicTotalMin() {
       const v = Number(this.digits) + Number(this.symbols)
       return v < 4 ? 4 : v
     },
-    SYMBOL_CHARS() {
-      return '/*-+.,!#$%&()~|_'.split('')
-    },
-    SYMBOL_VIEW_COUNT() {
-      return 3
-    }
+    SYMBOL_VIEW_COUNT: () => 3
   },
   watch: {
     strength() {
@@ -68,24 +104,10 @@ export default {
     }
   },
   mounted: function() {
-    this.strength = 'normal'
-    this.symbolChars = this.SYMBOL_CHARS
+    this.initialize()
   },
   methods: {
-    setPreset() {
-      switch (this.strength) {
-        case 'normal':
-          this.total = 12
-          this.digits = 4
-          this.symbols = 0
-          break
-        case 'strong':
-          this.total = 24
-          this.digits = 5
-          this.symbols = 5
-          break
-      }
-    },
+    ...mapActions('conditions', ['initialize', 'setPreset']),
     async submit() {
       await this.$store.dispatch('generate', {
         total: this.total,

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -33,7 +33,7 @@ module.exports = {
   css: ['~/assets/style/app.styl'],
 
   /* Plugins to load before mounting the App */
-  plugins: ['@/plugins/vuetify'],
+  plugins: ['@/plugins/vuetify', '@/plugins/vuex-persistedstate.js'],
 
   /* Nuxt.js modules */
   modules: ['nuxt-clipboard2'],

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "pug-plain-loader": "^1.0.0",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.2",
-    "vuetify": "^1.2.4"
+    "vuetify": "^1.2.4",
+    "vuex-persistedstate": "^2.5.4"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.1",

--- a/plugins/vuex-persistedstate.js
+++ b/plugins/vuex-persistedstate.js
@@ -1,0 +1,11 @@
+import createPersistedState from 'vuex-persistedstate'
+
+export default ({ store, isHMR }) => {
+  if (isHMR) return
+
+  window.onNuxtReady(() => {
+    createPersistedState({
+      paths: ['conditions']
+    })(store)
+  })
+}

--- a/store/conditions.js
+++ b/store/conditions.js
@@ -1,0 +1,43 @@
+export const state = () => ({
+  strength: null,
+  total: 0,
+  digits: 0,
+  symbols: 0,
+  generates: 5,
+  symbolChars: []
+})
+
+export const getters = {
+  isCustom: state => state.strength === 'custom',
+  SYMBOL_CHARS: () => '/*-+.,!#$%&()~|_'.split('')
+}
+
+export const mutations = {
+  update(state, { name, value }) {
+    if (name in state) {
+      state[name] = value
+    }
+  }
+}
+
+export const actions = {
+  initialize({ getters, commit }) {
+    commit('update', { name: 'strength', value: 'normal' })
+    commit('update', { name: 'symbolChars', value: getters.SYMBOL_CHARS })
+  },
+  setPreset({ state, commit }) {
+    switch (state.strength) {
+      case 'normal':
+        commit('update', { name: 'total', value: 12 })
+        commit('update', { name: 'digits', value: 4 })
+        commit('update', { name: 'symbols', value: 0 })
+        break
+
+      case 'strong':
+        commit('update', { name: 'total', value: 24 })
+        commit('update', { name: 'digits', value: 5 })
+        commit('update', { name: 'symbols', value: 5 })
+        break
+    }
+  }
+}

--- a/store/index.js
+++ b/store/index.js
@@ -3,6 +3,10 @@ export const state = () => ({
   generating: false
 })
 
+export const getters = {
+  generating: state => state.generating
+}
+
 export const mutations = {
   start(state) {
     state.passwords = []

--- a/yarn.lock
+++ b/yarn.lock
@@ -2274,7 +2274,7 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
-deepmerge@^2.2.1:
+deepmerge@^2.1.0, deepmerge@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
 
@@ -5778,6 +5778,10 @@ shell-quote@^1.6.1:
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
 
+shvl@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/shvl/-/shvl-1.3.1.tgz#6c20a17b4a20b08e9f8cab60c50a92229fcc176e"
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -6558,6 +6562,13 @@ vue@^2.5.17:
 vuetify@^1.2.4:
   version "1.3.11"
   resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-1.3.11.tgz#8be51f752a821704bb7fe0b7ac1f9324b902e52a"
+
+vuex-persistedstate@^2.5.4:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/vuex-persistedstate/-/vuex-persistedstate-2.5.4.tgz#a19710ad7f9a08cea4e65fc585924d9fdac7384a"
+  dependencies:
+    deepmerge "^2.1.0"
+    shvl "^1.3.0"
 
 vuex@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
fix https://github.com/tes-inc/password-generator/issues/13

## 生成条件を vuex 化

- computed の get, set を使って、ちょっと無理やり v-model に渡せるようにした

## vuex にした生成条件を localStorage で保持

- [vuex-persistedstate](https://github.com/robinvdvleuten/vuex-persistedstate) を使用
